### PR TITLE
Format Title and Description fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,15 @@
 Package: weightedSurv
-Title: Survival analysis with subject-specific (case weights) and time-dependent weighting
+Title: Survival Analysis with Subject-Specific (Case Weights) and Time-Dependent Weighting
 Version: 0.0.0.9000
 Authors@R: 
     person("Larry", "Leon", , "larry.leon.05@post.harvard.edu", role = c("aut", "cre"))
-Description: Survival analysis functions allowing for time-dependent and subject-specific (eg, propensity-scores) weighting. Weighted estimation for Cox model, Kaplan-Meier treatment survival curves as well as treatment difference along with point-wise and simultaneous confidence bands, and restricted mean survival time comparisons where RMST estimates are evaluated across all potential truncation times (point-wise and simultaneous bands).
+Description:
+  Survival analysis functions allowing for time-dependent and subject-specific
+  (eg, propensity-scores) weighting. Weighted estimation for Cox model,
+  Kaplan-Meier treatment survival curves as well as treatment difference along
+  with point-wise and simultaneous confidence bands, and restricted mean
+  survival time comparisons where RMST estimates are evaluated across all
+  potential truncation times (point-wise and simultaneous bands).
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Follow-up to 556dc4a639e404f883c8209d0503fa3f45cd8063

CRAN requires the `Title` field to be in Title Case:

```
The Title field should be in title case. Current version is:
'Survival analysis with subject-specific (case weights) and time-dependent weighting'
In title case that is:
'Survival Analysis with Subject-Specific (Case Weights) and Time-Dependent Weighting'
```

R couldn't parse `DESCRIPTION` when the first line of the field `Description` ended in a colon. I fixed this by starting the description on the following line.