### PR TITLE
Run and fix examples

### DIFF
--- a/R/df_counting.R
+++ b/R/df_counting.R
@@ -77,10 +77,9 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
 #' # Basic survival analysis
 #' library(survival)
-#' data(veteran)
+#' str(veteran)
 #' veteran$treat <- as.numeric(veteran$trt) - 1
 #'
 #' result <- df_counting(
@@ -113,7 +112,6 @@
 #'   treat.name = "treat",
 #'   strata.name = "celltype"
 #' )
-#' }
 #'
 #' @seealso
 #' \code{\link[survival]{coxph}}, \code{\link[survival]{survdiff}}, \code{\link[survival]{survfit}}

--- a/R/km_wlr_calculations_helpers.R
+++ b/R/km_wlr_calculations_helpers.R
@@ -368,9 +368,8 @@ resampling_survival <- function(U, W, D, at.points, draws.band, surv, G_draws) {
 #' @note Treatment must be coded as 0=control, 1=experimental. Event must be binary (0/1).
 #'
 #' @examples
-#' \dontrun{
 #' library(survival)
-#' data(veteran)
+#' str(veteran)
 #' veteran$treat <- as.numeric(veteran$trt) - 1
 #'
 #' # Basic KM difference
@@ -394,7 +393,6 @@ resampling_survival <- function(U, W, D, at.points, draws.band, surv, G_draws) {
 #'   draws.band = 1000,
 #'   modify_tau = TRUE
 #' )
-#' }
 #'
 #' @seealso
 #' \code{\link{df_counting}} for full survival analysis
@@ -409,7 +407,7 @@ resampling_survival <- function(U, W, D, at.points, draws.band, surv, G_draws) {
 #' @export
 
 KM_diff <- function(df, tte.name = "tte", event.name = "event", treat.name = "treat", weight.name=NULL, at_points = sort(df[[tte.name]]), alpha = 0.05, seedstart = 8316951, draws = 0,
-                    risk.points, draws.band = 0, tau.seq = 0.25, qtau = 0.025, show_resamples = TRUE, modify_tau = FALSE) {
+                    risk.points = NULL, draws.band = 0, tau.seq = 0.25, qtau = 0.025, show_resamples = TRUE, modify_tau = FALSE) {
 
   required_cols <- c(tte.name, event.name, treat.name)
   missing_cols <- setdiff(required_cols, names(df))

--- a/R/package.R
+++ b/R/package.R
@@ -44,11 +44,10 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
 #' library(survival)
-#' data(veteran)
+#' str(veteran)
 #' veteran$treat <- as.numeric(veteran$trt) - 1
-#' 
+#'
 #' # Basic analysis
 #' result <- df_counting(
 #'   df = veteran,
@@ -56,10 +55,10 @@
 #'   event.name = "status",
 #'   treat.name = "treat"
 #' )
-#' 
+#'
 #' # Plot results
 #' plot_weighted_km(result)
-#' 
+#'
 #' # Weighted log-rank emphasizing late differences
 #' result_fh <- df_counting(
 #'   df = veteran,
@@ -69,7 +68,6 @@
 #'   scheme = "fh",
 #'   scheme_params = list(rho = 0, gamma = 1)
 #' )
-#' }
 #'
 #' @references
 #' Fleming, T. R. and Harrington, D. P. (1991). Counting Processes and Survival Analysis. Wiley.

--- a/R/weightedCox.R
+++ b/R/weightedCox.R
@@ -219,10 +219,9 @@ cox_score_rhogamma <- function(beta, time, delta, z, w_hat = rep(1,length(time))
 #' @note The treatment variable in \code{dfcount} must be coded as 0=control, 1=experimental.
 #'
 #' @examples
-#' \dontrun{
 #' # First get counting process data
 #' library(survival)
-#' data(veteran)
+#' str(veteran)
 #' veteran$treat <- as.numeric(veteran$trt) - 1
 #'
 #' dfcount <- df_counting(
@@ -247,7 +246,6 @@ cox_score_rhogamma <- function(beta, time, delta, z, w_hat = rep(1,length(time))
 #' # Compare asymptotic and resampling CIs
 #' print(fit$hr_ci_asy)
 #' print(fit$hr_ci_star)
-#' }
 #'
 #' @seealso
 #' \code{\link{df_counting}} for preprocessing

--- a/R/weighted_helpers.R
+++ b/R/weighted_helpers.R
@@ -58,7 +58,6 @@
 #' # Standard log-rank (equal weights)
 #' w_lr <- wt.rg.S(surv, scheme = "fh", rho = 0, gamma = 0)
 #'
-#' \donttest{
 #' # Plotting examples
 #' plot(time, w_fh01, type = "l", main = "FH(0,1) Weights")
 #' plot(time, w_mb, type = "l", main = "MB(12) Weights")
@@ -67,7 +66,6 @@
 #' plot(time, w_lr, type = "l", ylim = c(0, 2))
 #' lines(time, w_fh01, col = "blue")
 #' legend("topleft", c("Log-rank", "FH(0,1)"), col = 1:2, lty = 1)
-#' }
 #'
 #' @references
 #' Fleming, T. R. and Harrington, D. P. (1991). Counting Processes and Survival Analysis. Wiley.

--- a/man/KM_diff.Rd
+++ b/man/KM_diff.Rd
@@ -14,7 +14,7 @@ KM_diff(
   alpha = 0.05,
   seedstart = 8316951,
   draws = 0,
-  risk.points,
+  risk.points = NULL,
   draws.band = 0,
   tau.seq = 0.25,
   qtau = 0.025,
@@ -96,9 +96,8 @@ Treatment must be coded as 0=control, 1=experimental. Event must be binary (0/1)
 }
 
 \examples{
-\dontrun{
 library(survival)
-data(veteran)
+str(veteran)
 veteran$treat <- as.numeric(veteran$trt) - 1
 
 # Basic KM difference
@@ -122,7 +121,6 @@ result_band <- KM_diff(
   draws.band = 1000,
   modify_tau = TRUE
 )
-}
 
 }
 \seealso{

--- a/man/cox_rhogamma.Rd
+++ b/man/cox_rhogamma.Rd
@@ -86,10 +86,9 @@ The score test at \eqn{\beta=0} corresponds to the weighted log-rank test.
 The treatment variable in \code{dfcount} must be coded as 0=control, 1=experimental.
 }
 \examples{
-\dontrun{
 # First get counting process data
 library(survival)
-data(veteran)
+str(veteran)
 veteran$treat <- as.numeric(veteran$trt) - 1
 
 dfcount <- df_counting(
@@ -114,7 +113,6 @@ print(fit$zlogrank_text)  # Weighted log-rank test
 # Compare asymptotic and resampling CIs
 print(fit$hr_ci_asy)
 print(fit$hr_ci_star)
-}
 
 }
 \references{

--- a/man/df_counting.Rd
+++ b/man/df_counting.Rd
@@ -144,10 +144,9 @@ For stratified analyses, stratum-specific estimates are computed and combined ap
 }
 
 \examples{
-\dontrun{
 # Basic survival analysis
 library(survival)
-data(veteran)
+str(veteran)
 veteran$treat <- as.numeric(veteran$trt) - 1
 
 result <- df_counting(
@@ -180,7 +179,6 @@ result_strat <- df_counting(
   treat.name = "treat",
   strata.name = "celltype"
 )
-}
 
 }
 \references{

--- a/man/weightedsurv-package.Rd
+++ b/man/weightedsurv-package.Rd
@@ -58,9 +58,8 @@ The package supports multiple weighting schemes for log-rank tests:
 }
 
 \examples{
-\dontrun{
 library(survival)
-data(veteran)
+str(veteran)
 veteran$treat <- as.numeric(veteran$trt) - 1
 
 # Basic analysis
@@ -83,7 +82,6 @@ result_fh <- df_counting(
   scheme = "fh",
   scheme_params = list(rho = 0, gamma = 1)
 )
-}
 
 }
 \references{

--- a/man/wt.rg.S.Rd
+++ b/man/wt.rg.S.Rd
@@ -90,7 +90,6 @@ w_mb <- wt.rg.S(surv, scheme = "MB", mb_tstar = 12, tpoints = time)
 # Standard log-rank (equal weights)
 w_lr <- wt.rg.S(surv, scheme = "fh", rho = 0, gamma = 0)
 
-\donttest{
 # Plotting examples
 plot(time, w_fh01, type = "l", main = "FH(0,1) Weights")
 plot(time, w_mb, type = "l", main = "MB(12) Weights")
@@ -99,7 +98,6 @@ plot(time, w_mb, type = "l", main = "MB(12) Weights")
 plot(time, w_lr, type = "l", ylim = c(0, 2))
 lines(time, w_fh01, col = "blue")
 legend("topleft", c("Log-rank", "FH(0,1)"), col = 1:2, lty = 1)
-}
 
 }
 \references{


### PR DESCRIPTION
The examples were not being run, and thus errors were being hidden.

The most common error was `data(veteran)`. This is produces an error:

```R
library(survival)
data(veteran)
## Warning message:
## In data(veteran) : data set ‘veteran’ not found
```

You could run `data(cancer)`, but that loads many other data sets in addition to `veteran`. Instead, you can just refer to `veteran` directly.

```R
library(survival)
str(veteran)
## 'data.frame':	137 obs. of  8 variables:
##  $ trt     : num  1 1 1 1 1 1 1 1 1 1 ...
##  $ celltype: Factor w/ 4 levels "squamous","smallcell",..: 1 1 1 1 1 1 1 1 1 1 ...
##  $ time    : num  72 411 228 126 118 10 82 110 314 100 ...
##  $ status  : num  1 1 1 1 1 1 1 1 1 0 ...
##  $ karno   : num  60 70 60 60 70 20 40 80 50 70 ...
##  $ diagtime: num  7 5 3 9 11 5 10 29 18 6 ...
##  $ age     : num  69 64 38 63 65 49 69 68 43 70 ...
##  $ prior   : num  0 10 0 10 10 0 10 0 0 0 ...
```

The second error was not passing a value for `risk.points` to `KM_diff()`. I couldn't find any example where `risk.points` was manually defined elsewhere in the package, so I set `risk.points = NULL`. Looking at the function code, this should cause it to have no effect on `at_points`.

https://github.com/larry-leon/weightedsurv/blob/bd719d2e30364ea768b2aee81b6df306788fab34/R/km_wlr_calculations_helpers.R#L451-L457